### PR TITLE
Make header classes accessible to the 

### DIFF
--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -770,6 +770,7 @@ pub fn markdown_to_html(
                 permalink,
                 title,
                 children: Vec::new(),
+                classes: heading_ref.classes.clone(),
             };
             headings.push(h);
         }

--- a/components/markdown/tests/toc.rs
+++ b/components/markdown/tests/toc.rs
@@ -75,3 +75,26 @@ fn can_make_toc_all_levels() {
     assert_eq!(toc[0].children[1].children[0].children.len(), 1);
     assert_eq!(toc[0].children[1].children[0].children[0].children.len(), 1);
 }
+
+#[test]
+fn can_make_toc_classes() {
+    let res = common::render(
+        r#"
+## Heading with no classes
+
+## Heading with one class {.class}
+
+## Heading with two classes {.class1 .class2}
+"#,
+    )
+    .unwrap();
+
+    let toc = res.toc;
+    assert_eq!(toc.len(), 3);
+    assert!(toc[0].classes.is_empty());
+    assert_eq!(toc[1].classes.len(), 1);
+    assert_eq!(toc[1].classes[0], "class");
+    assert_eq!(toc[2].classes.len(), 2);
+    assert_eq!(toc[2].classes[0], "class1");
+    assert_eq!(toc[2].classes[1], "class2");
+}

--- a/components/utils/src/table_of_contents.rs
+++ b/components/utils/src/table_of_contents.rs
@@ -8,6 +8,7 @@ pub struct Heading {
     pub permalink: String,
     pub title: String,
     pub children: Vec<Heading>,
+    pub classes: Vec<Heading>
 }
 
 impl Heading {


### PR DESCRIPTION
Make header classes accessible in the table of contents.

Small, hopefully inoffensive change.